### PR TITLE
PocketBeagle-2: rgb-color: color_circle: Only have base colors

### DIFF
--- a/PocketBeagle-2/rgb_led/color_circle/README.md
+++ b/PocketBeagle-2/rgb_led/color_circle/README.md
@@ -8,4 +8,5 @@ Demonstrate generating different colors in the color circle.
 
 ## Challenges
 
-1. Can you try out creating other colors?
+1. Can you try out creating other colors such as Teal, etc?
+2. Can you try out creating white?

--- a/PocketBeagle-2/rgb_led/color_circle/python/main.py
+++ b/PocketBeagle-2/rgb_led/color_circle/python/main.py
@@ -1,5 +1,5 @@
 """
-This example cycles through all the base colors in the Color circle.
+This example cycles through the base colors in the Color circle.
 """
 
 from sysfs import Device
@@ -21,23 +21,8 @@ while True:
     multi_intensity.write('255 0 0')
     sleep(DELAY)
 
-    multi_intensity.write('255 255 0')
-    sleep(DELAY)
-
     multi_intensity.write('0 255 0')
     sleep(DELAY)
 
-    multi_intensity.write('0 255 255')
-    sleep(DELAY)
-
     multi_intensity.write('0 0 255')
-    sleep(DELAY)
-
-    multi_intensity.write('255 0 255')
-    sleep(DELAY)
-
-    multi_intensity.write('255 255 255')
-    sleep(DELAY)
-
-    multi_intensity.write('0 0 0')
     sleep(DELAY)

--- a/PocketBeagle-2/rgb_led/color_circle/rust/src/main.rs
+++ b/PocketBeagle-2/rgb_led/color_circle/rust/src/main.rs
@@ -1,4 +1,4 @@
-//! This example cycles through all the base colors in the Color circle.
+//! This example cycles through the base colors in the Color circle.
 
 use std::{io::Write, thread::sleep, time::Duration};
 
@@ -26,25 +26,10 @@ fn main() {
         multi_intensity.write_all(b"255 0 0").unwrap();
         sleep(DELAY);
 
-        multi_intensity.write_all(b"255 255 0").unwrap();
-        sleep(DELAY);
-
         multi_intensity.write_all(b"0 255 0").unwrap();
         sleep(DELAY);
 
-        multi_intensity.write_all(b"0 255 255").unwrap();
-        sleep(DELAY);
-
         multi_intensity.write_all(b"0 0 255").unwrap();
-        sleep(DELAY);
-
-        multi_intensity.write_all(b"255 0 255").unwrap();
-        sleep(DELAY);
-
-        multi_intensity.write_all(b"255 255 255").unwrap();
-        sleep(DELAY);
-
-        multi_intensity.write_all(b"0 0 0").unwrap();
         sleep(DELAY);
     }
 }


### PR DESCRIPTION
- As discussed in the examples, the complex colors can be left as a challenge