### PR TITLE
Revert "PocketBeagle-2: rgb_led: LED Path has changed after update"

### DIFF
--- a/PocketBeagle-2/rgb_led/color_circle/python/main.py
+++ b/PocketBeagle-2/rgb_led/color_circle/python/main.py
@@ -6,7 +6,7 @@ from sysfs import Device
 from pathlib import Path
 from time import sleep
 
-LED = Path("/sys/devices/platform/techlab-led/leds/rgb:/")
+LED = Path("/sys/devices/platform/techlab-led/leds/multi-led/")
 DELAY = 1
 
 led = Device(path=LED)

--- a/PocketBeagle-2/rgb_led/color_circle/rust/src/main.rs
+++ b/PocketBeagle-2/rgb_led/color_circle/rust/src/main.rs
@@ -4,7 +4,7 @@ use std::{io::Write, thread::sleep, time::Duration};
 
 use beagle_helper::sysfs::Device;
 
-const LED: &str = "/sys/devices/platform/techlab-led/leds/rgb:/";
+const LED: &str = "/sys/devices/platform/techlab-led/leds/multi-led/";
 const DELAY: Duration = Duration::from_secs(1);
 
 fn main() {

--- a/PocketBeagle-2/rgb_led/fade_brightness/python/main.py
+++ b/PocketBeagle-2/rgb_led/fade_brightness/python/main.py
@@ -2,7 +2,7 @@ from sysfs import Device
 from pathlib import Path
 from time import sleep
 
-LED = Path("/sys/devices/platform/techlab-led/leds/rgb:/")
+LED = Path("/sys/devices/platform/techlab-led/leds/multi-led/")
 DELAY = 0.05
 
 led = Device(path=LED)

--- a/PocketBeagle-2/rgb_led/fade_brightness/rust/src/main.rs
+++ b/PocketBeagle-2/rgb_led/fade_brightness/rust/src/main.rs
@@ -5,7 +5,7 @@ use std::{io::Write, thread::sleep, time::Duration};
 
 use beagle_helper::sysfs::Device;
 
-const LED: &str = "/sys/devices/platform/techlab-led/leds/rgb:/";
+const LED: &str = "/sys/devices/platform/techlab-led/leds/multi-led/";
 const DELAY: Duration = Duration::from_millis(50);
 
 fn main() {

--- a/PocketBeagle-2/rgb_led/fade_intensity/python/main.py
+++ b/PocketBeagle-2/rgb_led/fade_intensity/python/main.py
@@ -2,7 +2,7 @@ from sysfs import Device
 from pathlib import Path
 from time import sleep
 
-LED = Path("/sys/devices/platform/techlab-led/leds/rgb:/")
+LED = Path("/sys/devices/platform/techlab-led/leds/multi-led/")
 DELAY = 0.05
 MAX_INTENSITY = 255
 

--- a/PocketBeagle-2/rgb_led/fade_intensity/rust/src/main.rs
+++ b/PocketBeagle-2/rgb_led/fade_intensity/rust/src/main.rs
@@ -5,7 +5,7 @@ use std::{io::Write, thread::sleep, time::Duration};
 
 use beagle_helper::sysfs::Device;
 
-const LED: &str = "/sys/devices/platform/techlab-led/leds/rgb:/";
+const LED: &str = "/sys/devices/platform/techlab-led/leds/multi-led/";
 const DELAY: Duration = Duration::from_millis(50);
 
 const MAX_INTENSITY: usize = 255;

--- a/PocketBeagle-2/rgb_led/hue/python/main.py
+++ b/PocketBeagle-2/rgb_led/hue/python/main.py
@@ -18,7 +18,7 @@ def wheel(pos: int) -> tuple[int, int, int]:
         return (pos * 3, 255 - pos * 3, 0)
 
 
-LED = Path("/sys/devices/platform/techlab-led/leds/rgb:/")
+LED = Path("/sys/devices/platform/techlab-led/leds/multi-led/")
 DELAY = 0.01
 
 led = Device(path=LED)

--- a/PocketBeagle-2/rgb_led/hue/rust/src/main.rs
+++ b/PocketBeagle-2/rgb_led/hue/rust/src/main.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use beagle_helper::sysfs::Device;
 
-const LED: &str = "/sys/devices/platform/techlab-led/leds/rgb:/";
+const LED: &str = "/sys/devices/platform/techlab-led/leds/multi-led/";
 const DELAY: Duration = Duration::from_millis(10);
 
 /// Helper function to convert hue to RGB


### PR DESCRIPTION
Reverts beagleboard/vsx-examples#24
- This was born out of Armbian, which ships 6.16. However, the workshop images will ship 6.12 for a while longer, so revert this for now.